### PR TITLE
Update Lottery Contract Adding ERC20 Tokens

### DIFF
--- a/contracts/Games/lottery_game.sol
+++ b/contracts/Games/lottery_game.sol
@@ -1,33 +1,33 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity ^0.8.14;
-
-contract lottery{
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+contract lottery is ERC20{
     address public owner;
     address payable[] public players;
 
-    constructor(){
+    constructor()ERC20("OpenCode","OPC"){
         // address of owner who is deploying the contract
         owner = msg.sender;
+        _mint(owner,10000*(10**18));
     }
 
     function enter() public payable {
         //preset entry fee;
-        require(msg.value > 0.1 ether);
+        require(msg.value >= 100);
 
         // adrress of the player entering the lottery
         players.push(payable(msg.sender));
     }
 
-    function getRandomNumber() public view returns (uint){
+    function _getRandomNumber() private view returns (uint){
         // generating a hash number by concatenating both owner address and timestamp then converting it unsigned int..
         return uint(keccak256(abi.encodePacked(owner,block.timestamp)));
     }
 
     function pickWinner() public onlyowner {
-        uint index = getRandomNumber() % players.length;
-        players[index].transfer(address(this).balance);
-
+        uint index = _getRandomNumber() % players.length;
+        super._transfer(owner, players[index], 100*(10**18));// Transfer 100 OPC tokens to winner from owner account 
+        // players[index].transfer(address(this).balance);
         // reset contract
         players = new address payable[](0);
     }


### PR DESCRIPTION
Issue: 48


#### Short description of what this resolves:
Changes Made :- 
-Transfer 100 OPC tokens to every winner in lottery .
- Make get random number function private to avoid any loop hole .
- Attach A receipt of transfer 100 opc to one owner to winner address .
- Etherscan Link :- [https://goerli.etherscan.io/tx/0x4ddd29b8958845aaeedc513c178251cac37423102c1a0f746988a74b7aa75d13](url) 
-ERC20 token import from oppenzepplin Library 


#### Changes proposed in this pull request and/or Screenshots of changes:
<img width="904" alt="erc20" src="https://user-images.githubusercontent.com/82640789/209439593-98a3bc24-0d6a-4441-ad64-59555f96f2ad.png">
-
-
-