### PR TITLE
Fixed GameOver.sol

### DIFF
--- a/contracts/Security/GameOver.sol
+++ b/contracts/Security/GameOver.sol
@@ -10,11 +10,13 @@ pragma solidity ^0.8.17;
 contract MyGame {
     uint public target = 5 ether;
     address public winner;
-
+    uint public balance;
+    // manually maintaining a balance that only updates when the deposit function is called
     function deposit() public payable {
         require(msg.value == 1 ether, "You can only send 1 Ether");
 
-        uint balance = address(this).balance;
+        balance += msg.value;
+        // uint balance = address(this).balance;
         require(balance <= target, "Game is over");
 
         if (balance == target) {
@@ -24,9 +26,10 @@ contract MyGame {
 
     function claimReward() public {
         require(msg.sender == winner, "Not winner");
-
-        (bool sent, ) = msg.sender.call{value: address(this).balance}("");
+        
+        (bool sent, ) = msg.sender.call{value: balance}("");
         require(sent, "Failed to send Ether");
+        balance = 0;
     }
 }
 


### PR DESCRIPTION
Issue: 61

This PR is an attempt to fix issue #61 

The Smart Contract "GameOver.sol" had a security vulnerability. 

In the contract, we explicitly use address(this).balance to transfer money from the contract to the winner. An attacker could send some ether to the contract via the selfdestruct function. When this happens, there will never be a winner since the contract balance will never reach exactly five ethers using the deposit() function. 

By explicitly using a balance variable that only updates by a value of 1 ether (contract execution reverted otherwise) on calling the deposit() function, the problem described above will never creep up. 